### PR TITLE
Add a link to the Arch Linux Wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # pkglint
-Implementation of namcap rules for libmakepkg
+Implementation of namcap rules for libmakepkg.
+See the [Arch Linux Wiki](https://wiki.archlinux.org/index.php/User:Allan/pkglint) for the current progress and unhandled namcap rules.


### PR DESCRIPTION
Add a link to the wiki page which has a list of currently implemented and missing rules.
